### PR TITLE
Add CJS support to builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skynethq/content-record-library",
-  "version": "0.2.6-beta",
+  "version": "0.2.7-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skynethq/content-record-library",
-      "version": "0.2.6-beta",
+      "version": "0.2.7-beta",
       "license": "MIT",
       "dependencies": {
         "post-me": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "@skynethq/content-record-library",
   "version": "0.2.7-beta",
   "description": "This library exposes a class that wraps the Content Record DAC, created and hosted by SkynetLabs.",
-  "main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
   "type": "module",
   "files": [
     "dist/*"
   ],
   "scripts": {
-    "build": "rimraf dist && tsc --project tsconfig.build.json",
+    "build": "rimraf dist && tsc -p tsconfig.build.json && tsc -p tsconfig.build.cjs.json",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist/cjs"
+  },
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,8 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "isolatedModules": true,
-    "outDir": "dist",
-
+    "outDir": "dist/esm",
     "moduleResolution": "node",
     "target": "esnext",
     "types": ["node"]


### PR DESCRIPTION
- Modify `build` to output both CJS and ESM module formats