### PR TITLE
Remove type module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "This library exposes a class that wraps the Content Record DAC, created and hosted by SkynetLabs.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "type": "module",
   "files": [
     "dist/*"
   ],


### PR DESCRIPTION
- This package.json option is confusing the CJS loader, removing as unnecessary